### PR TITLE
Updated LogCommands.cs

### DIFF
--- a/src/NadekoBot/Modules/Administration/LogCommands.cs
+++ b/src/NadekoBot/Modules/Administration/LogCommands.cs
@@ -36,7 +36,6 @@ namespace NadekoBot.Modules.Administration
             [NadekoCommand, Usage, Description, Aliases]
             [RequireContext(ContextType.Guild)]
             [RequireUserPermission(GuildPermission.Administrator)]
-            [OwnerOnly]
             public async Task LogServer(PermissionAction action)
             {
                 var channel = (ITextChannel)Context.Channel;
@@ -72,7 +71,6 @@ namespace NadekoBot.Modules.Administration
             [NadekoCommand, Usage, Description, Aliases]
             [RequireContext(ContextType.Guild)]
             [RequireUserPermission(GuildPermission.Administrator)]
-            [OwnerOnly]
             public async Task LogIgnore()
             {
                 var channel = (ITextChannel)Context.Channel;
@@ -101,7 +99,6 @@ namespace NadekoBot.Modules.Administration
             [NadekoCommand, Usage, Description, Aliases]
             [RequireContext(ContextType.Guild)]
             [RequireUserPermission(GuildPermission.Administrator)]
-            [OwnerOnly]
             public async Task LogEvents()
             {
                 await Context.Channel.SendConfirmAsync(Format.Bold(GetText("log_events")) + "\n" +
@@ -112,7 +109,6 @@ namespace NadekoBot.Modules.Administration
             [NadekoCommand, Usage, Description, Aliases]
             [RequireContext(ContextType.Guild)]
             [RequireUserPermission(GuildPermission.Administrator)]
-            [OwnerOnly]
             public async Task Log(LogType type)
             {
                 var channel = (ITextChannel)Context.Channel;


### PR DESCRIPTION
An issue with the permissions led to a simultaneous requirement of the user executing the command having to be both a server administrator AND the bot owner. So one could not have their bot have logging on other servers where they are not an admin.